### PR TITLE
Fix twitter card for nix post

### DIFF
--- a/src/posts/2021-12-13-a_minimal_nix_shell.md
+++ b/src/posts/2021-12-13-a_minimal_nix_shell.md
@@ -1,6 +1,6 @@
 ---
 title: A gentle introduction to Nix
-description: A few lines of code, and a very gentle introduction to a very complicated package manager
+excerpt: A few lines of code, and a very gentle introduction to a very complicated package manager
 author: jennablumenthal
 date: 2021-12-13
 tags:


### PR DESCRIPTION
Our SEO plugin uses `excerpt` to populate the cards description